### PR TITLE
Expose a `bundle_adjustment` function

### DIFF
--- a/pipeline/sfm.cc
+++ b/pipeline/sfm.cc
@@ -3,6 +3,7 @@
 #include "colmap/exe/sfm.h"
 #include "colmap/base/camera_models.h"
 #include "colmap/base/reconstruction.h"
+#include "colmap/controllers/bundle_adjustment.h"
 #include "colmap/controllers/incremental_mapper.h"
 #include "colmap/util/misc.h"
 
@@ -104,6 +105,33 @@ std::map<size_t, Reconstruction> incremental_mapping(
     return reconstructions;
 }
 
+// Copied from colmap/exe/sfm.cc
+Reconstruction bundle_adjustment(
+    const py::object input_path_,
+    const py::object output_path_,
+    const BundleAdjustmentOptions& ba_options
+) {
+    std::string input_path = py::str(input_path_).cast<std::string>();
+    std::string output_path = py::str(output_path_).cast<std::string>();
+
+    THROW_CHECK_DIR_EXISTS(input_path);
+    THROW_CHECK_DIR_EXISTS(output_path);
+
+    Reconstruction reconstruction;
+    reconstruction.Read(input_path);
+
+    OptionManager options;
+    *options.bundle_adjustment = ba_options;
+
+    BundleAdjustmentController ba_controller(options, &reconstruction);
+    ba_controller.Start();
+    ba_controller.Wait();
+
+    reconstruction.Write(output_path);
+
+    return reconstruction;
+}
+
 std::map<size_t, Reconstruction> incremental_mapping(
     const py::object database_path_,
     const py::object image_path_,
@@ -183,6 +211,71 @@ void init_sfm(py::module& m) {
     make_dataclass(PyIncrementalMapperOptions);
     auto mapper_options = PyIncrementalMapperOptions().cast<Opts>();
 
+    using BAOpts = BundleAdjustmentOptions;
+    auto PyBALossFunctionType =
+        py::enum_<BAOpts::LossFunctionType>(m, "LossFunctionType")
+            .value("TRIVIAL", BAOpts::LossFunctionType::TRIVIAL)
+            .value("SOFT_L1", BAOpts::LossFunctionType::SOFT_L1)
+            .value("CAUCHY", BAOpts::LossFunctionType::CAUCHY);
+    AddStringToEnumConstructor(PyBALossFunctionType);
+    using CSOpts = ceres::Solver::Options;
+    auto PyCeresSolverOptions =
+        py::class_<CSOpts>(m,
+                           "CeresSolverOptions",
+                           // If ceres::Solver::Options is registered by pycolmap AND a downstream
+                           // library, importing the downstream library results in error:
+                           //   ImportError: generic_type: type "CeresSolverOptions" is already registered!
+                           // Adding a `py::module_local()` fixes this.
+                           // https://github.com/pybind/pybind11/issues/439#issuecomment-1338251822
+                           py::module_local())
+            .def(py::init<>())
+            .def_readwrite("function_tolerance", &CSOpts::function_tolerance)
+            .def_readwrite("gradient_tolerance", &CSOpts::gradient_tolerance)
+            .def_readwrite("parameter_tolerance", &CSOpts::parameter_tolerance)
+            .def_readwrite("minimizer_progress_to_stdout", &CSOpts::minimizer_progress_to_stdout)
+            .def_readwrite("minimizer_progress_to_stdout", &CSOpts::minimizer_progress_to_stdout)
+            .def_readwrite("max_num_iterations", &CSOpts::max_num_iterations)
+            .def_readwrite("max_linear_solver_iterations", &CSOpts::max_linear_solver_iterations)
+            .def_readwrite("max_num_consecutive_invalid_steps", &CSOpts::max_num_consecutive_invalid_steps)
+            .def_readwrite("max_consecutive_nonmonotonic_steps", &CSOpts::max_consecutive_nonmonotonic_steps)
+            .def_readwrite("num_threads", &CSOpts::num_threads);
+    make_dataclass(PyCeresSolverOptions);
+    auto PyBundleAdjustmentOptions =
+        py::class_<BAOpts>(m, "BundleAdjustmentOptions")
+            .def(py::init<>())
+            .def_readwrite("loss_function_type",
+                           &BAOpts::loss_function_type,
+                           "Loss function types: Trivial (non-robust) and Cauchy (robust) loss.")
+            .def_readwrite("loss_function_scale",
+                           &BAOpts::loss_function_scale,
+                           "Scaling factor determines residual at which robustification takes place.")
+            .def_readwrite("refine_focal_length",
+                           &BAOpts::refine_focal_length,
+                           "Whether to refine the focal length parameter group.")
+            .def_readwrite("refine_principal_point",
+                           &BAOpts::refine_principal_point,
+                           "Whether to refine the principal point parameter group.")
+            .def_readwrite("refine_extra_params",
+                           &BAOpts::refine_extra_params,
+                           "Whether to refine the extra parameter group.")
+            .def_readwrite("refine_extrinsics",
+                           &BAOpts::refine_extrinsics,
+                           "Whether to refine the extrinsic parameter group.")
+            .def_readwrite("print_summary",
+                           &BAOpts::print_summary,
+                           "Whether to print a final summary.")
+            .def_readwrite("min_num_residuals_for_multi_threading",
+                           &BAOpts::min_num_residuals_for_multi_threading,
+                           "Minimum number of residuals to enable multi-threading. Note that "
+                           "single-threaded is typically better for small bundle adjustment problems "
+                           "due to the overhead of threading. "
+                           )
+            .def_readwrite("solver_options",
+                           &BAOpts::solver_options,
+                           "Ceres-Solver options.");
+    make_dataclass(PyBundleAdjustmentOptions);
+    auto ba_options = PyBundleAdjustmentOptions().cast<BAOpts>();
+
     m.def("triangulate_points",
           &triangulate_points,
           py::arg("reconstruction"),
@@ -206,6 +299,12 @@ void init_sfm(py::module& m) {
           py::arg("options") = mapper_options,
           py::arg("input_path") = py::str(""),
           "Triangulate 3D points from known poses");
+
+    m.def("bundle_adjustment",
+          &bundle_adjustment,
+          py::arg("input_path"),
+          py::arg("output_path"),
+          py::arg("options") = ba_options);
 
     m.def("incremental_mapping",
           static_cast<std::map<size_t, Reconstruction> (*)(const py::object,


### PR DESCRIPTION
This commit exposes a `bundle_adjustment` function that has a similar functionality to the command line utility `colmap bundle_adjuster`.  One use case it enables is to allow one use pycolmap to run bundle adjustment after sparse reconstruction to refine the principal point, as jointly refining the principal point[^principal_point_refinement] during sparse reconstruction would make sparse reconstruction on some scenes to fail.

Note that not all available members of `ceres::Solver::Options` are exposed in this change, but only the ones modified by `BundleAdjustmentOptions` in colmap[^modified_solver_options].  Besides, the registered `CeresSolverOptions` uses `py::module_local()` to avoid conflicts with downstream libraries.

Example usage
=============

```python
from pathlib import Path

import pycolmap

sparse_reconstruction_directory = Path("sparse/0")  # or just `... = "sparse/0"`

ba_opts = {
  "refine_principal_point": True,
  "solver_options": {
    "max_num_iterations": 256,
  },
}

pycolmap.bundle_adjustment(
  input_path=sparse_reconstruction_directory,
  output_path=sparse_reconstruction_directory,
  options=ba_opts,
)
```

Known problem
=============

Though creating a `pycolmap.BundleAdjustmentOptions` object with a nested `dict` works as expected, i.e., the following examples work well:

```python
import pycolmap

ba_opts = pycolmap.BundleAdjustmentOptions({
  "refine_principal_point": True,
  "solver_options": {
    "max_num_iterations": 256,
  },
})
print(ba_opts.todict())  # runs successfully with user-specified option values

ba_opts = pycolmap.BundleAdjustmentOptions({
  refine_principal_point=True,
  solver_options={"max_num_iterations": 256},
})
print(ba_opts.todict())  # runs successfully with user-specified option values
```

it gives an error while trying to create a
`pycolmap.BundleAdjustmentOptions` object with its `solver_options` set to a `pycolmap.CeresSolverOptions` object, i.e. the following gives an error:

```python
import pycolmap

solver_options = pycolmap.CeresSolverOptions(max_num_iterations=256)
print(solver_options.todict())  # runs successfully with user-specified option values

ba_opts = pycolmap.BundleAdjustmentOptions({
  "refine_principal_point": True,
  "solver_options": solver_options
})  # RuntimeError: instance allocation failed: new instance has no pybind11-registered base types
```

The "new instance" mentioned in the RuntimeError message probably points to the `CeresSolverOptions` added in this commit, but I'm not sure about a way to solve this at the moment, plus, as reported above, using `dict`s to specify the option values works properly and works around this error.

[^principal_point_refinement]: <https://colmap.github.io/faq.html#frequently-asked-questions>
[^modified_solver_options]: <https://github.com/colmap/colmap/blob/3.8/src/optim/bundle_adjustment.h#L81-L89>